### PR TITLE
Fixed 8b => 4b conversion and packing

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -47,15 +47,14 @@ void ssd1322_lvgl_flush(lv_display_t *display, const lv_area_t *area, uint8_t *p
   oled.set_write_ram();
 
   for (uint16_t x = 0; x < pixels; x++) {
-      uint16_t z = x >> 1;
+    uint16_t z = x >> 1; // Each two pixels go into one byte
+    uint8_t pixel_4bit = buf[x] >> 4; // Conversion from 8-bit (0-255) to 4-bit (0-15)
 
-      if (x & 1u) {
-          pixel_buff[z] &= ~0x0f;
-          pixel_buff[z] |= buf[x] >> 4;
-      } else {
-          pixel_buff[z] &= ~0xf0;
-          pixel_buff[z] |= buf[x] << 4;
-      }
+    if (x & 1u) {
+        pixel_buff[z] |= pixel_4bit;  // Store lower 4 bits
+    } else {
+        pixel_buff[z] = (pixel_4bit << 4);  // Store upper 4 bits
+    }
   }
 
   oled.send_ssd1322_data_buffer(pixel_buff, bytes);

--- a/ssd1322.cpp
+++ b/ssd1322.cpp
@@ -1,5 +1,5 @@
 #include <ssd1322.h>
-#include <stdio.h>
+#include <cstdio>
 
 // cs - SPI chip select
 // dc - SPI data/command
@@ -68,7 +68,7 @@ void SSD1322::init(int columns, int rows) {
   // create SPI device
   spi_device_interface_config_t devcfg = {};
   devcfg.spics_io_num = this->cs;
-  devcfg.clock_speed_hz = SPI_MASTER_FREQ_8M;
+  devcfg.clock_speed_hz = SPI_MASTER_FREQ_8M; // Can handle 20 MHz
   devcfg.mode = 0;
   devcfg.queue_size = 200;
   devcfg.clock_source = SPI_CLK_SRC_DEFAULT; // SOC_MOD_CLK_APB;
@@ -79,8 +79,8 @@ void SSD1322::init(int columns, int rows) {
   devcfg.cs_ena_posttrans = 0;
   devcfg.cs_ena_pretrans = 0;
   devcfg.flags = 0;
-  devcfg.pre_cb = NULL;
-  devcfg.post_cb = NULL;
+  devcfg.pre_cb = nullptr;
+  devcfg.post_cb = nullptr;
 
   // init SPI
   spi_bus_initialize((spi_host_device_t)this->spi_host, &buscfg, SPI_DMA_CH_AUTO);

--- a/ssd1322.h
+++ b/ssd1322.h
@@ -3,7 +3,7 @@
 
 #include <driver/gpio.h>
 #include <driver/spi_master.h>
-#include <freertos/freertos.h>
+#include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 
 class SSD1322 {


### PR DESCRIPTION
Hi, I appreciate your driver for using LVGL on the SSD1322. Thanks for it—it saved me a lot of work. However, I had to slightly modify some parts to make it work correctly, especially the conversion from 8-bit to 4-bit in `ssd1322_lvgl_flush` and the proper storage into the pixel buffer.

Cheers,
Honza